### PR TITLE
Bump jackson-core to 2.22.1

### DIFF
--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "jacksonlinter",
-  "version": "2.19.2",
+  "version": "2.22.1",
   "patterns": [
     {
       "patternId": "parse-error",


### PR DESCRIPTION
## Summary
- Bumps the wrapped `jackson-core` version pinned in `src/main/resources/docs/patterns.json` from `2.19.2` to `2.22.1` (latest 2.x release on Maven Central for `com.fasterxml.jackson.core:jackson-core`).
- `build.sbt` reads this version automatically via `toolVersionKey`, so no other files need to change for this pure version bump (per the repo's Agent Playbook).
- Reviewed the 2.20-2.22 Jackson release notes; no changes to `JsonParseException` message format or duplicate-key detection messages that would affect `JsonLint.scala`'s parsing logic.

## Validation output

`sbt "clean; scalafmtCheckAll; Test/scalafmtCheck; scalafmtCheck; test"` - passed (no test sources exist in this repo; compiles cleanly, format checks pass).

`sbt 'set name := "codacy-jackson-linter"; set version in Docker := "latest"; docker:publishLocal'` - image built successfully.

`codacy-plugins-test` run locally against the built image:
- `DockerTest json codacy-jackson-linter:latest` -> `[Success] All tests passed!`
- `DockerTest pattern codacy-jackson-linter:latest` -> `[Success] All tests passed!` (all 4 fixtures in `docs/tests/*` matched expected patterns/lines)
- `DockerTest multiple codacy-jackson-linter:latest` -> `[Success] All tests passed!` (`docs/multiple-tests/*` fixtures)

Note: the json test prints a pre-existing warning `Could not read /docs/description/parse-error.md` (that file has never existed in this repo - `duplicate-keys.md` exists but `parse-error.md` does not). This is unrelated to the version bump and the test suite still reports overall success.

## Test plan
- [x] Local scalafmt/compile checks pass
- [x] Docker image builds
- [x] codacy-plugins-test json/pattern/multiple suites pass locally
- [ ] CI checks green (polling after push)